### PR TITLE
Update Readme file with correct linkedin and issues URL, Add MIT Template File

### DIFF
--- a/MIT.md
+++ b/MIT.md
@@ -1,0 +1,10 @@
+## Copyright 2021, [YOUR NAME]
+
+###### Please delete this line and the next one
+###### APP TYPE can be a webpage/website, a web app, a software and so on
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this [APP TYPE] and associated documentation files, to deal in the [APP TYPE] without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the [APP TYPE], and to permit persons to whom the [APP TYPE] is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the [APP TYPE].
+
+THE [APP TYPE] IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE [APP TYPE] OR THE USE OR OTHER DEALINGS IN THE [APP TYPE].

--- a/README.md
+++ b/README.md
@@ -47,19 +47,19 @@ To get a local copy up and running follow these simple example steps.
 
 - GitHub: [@githubhandle](https://github.com/githubhandle)
 - Twitter: [@twitterhandle](https://twitter.com/twitterhandle)
-- LinkedIn: [LinkedIn](https://linkedin.com/linkedinhandle)
+- LinkedIn: [LinkedIn](https://linkedin.com/in/linkedinhandle)
 
 👤 **Author2**
 
 - GitHub: [@githubhandle](https://github.com/githubhandle)
 - Twitter: [@twitterhandle](https://twitter.com/twitterhandle)
-- LinkedIn: [LinkedIn](https://linkedin.com/linkedinhandle)
+- LinkedIn: [LinkedIn](https://linkedin.com/in/linkedinhandle)
 
 ## 🤝 Contributing
 
 Contributions, issues, and feature requests are welcome!
 
-Feel free to check the [issues page](issues/).
+Feel free to check the [issues page](../../issues/).
 
 ## Show your support
 
@@ -73,4 +73,4 @@ Give a ⭐️ if you like this project!
 
 ## 📝 License
 
-This project is [MIT](lic.url) licensed.
+This project is [MIT](./MIT.md) licensed.


### PR DESCRIPTION
# Readme paths redirecting to the wrong page
> Both the Linkedin profile URL and the issues page URL takes the user to non-existent pages (404)

## Why change it on the template instead of relying on the developer
The template should be as straightforward as possible, and avoid as many confusions as possible.
Microverse can be quite challenging when you first get into it with all of its requirements, documentation, and so on, so we should always try to remove as many burdens as we can from our students' backs.

## Linkedin Profile Page URL
How it is right now:
`- LinkedIn: [LinkedIn](https://linkedin.com/linkedinhandle)`

What is going to be updated to:
`- LinkedIn: [LinkedIn](https://linkedin.com/in/linkedinhandle)`
> This way all that is required to change is the handle

## Issues Page on Github URL
How it is right now:
`Feel free to check the [issues page](issues/).`

What is going to be updated to:
`Feel free to check the [issues page](../../issues/).`
> This way nothing has to be done on the developer's side

## Additional changes :rocket:
Add an MIT Template file as well.